### PR TITLE
Migrate plugin to V2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "alto777_LFSR",
   "name": "LFSR",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "BSD-3-Clause",
   "brand": "alto777_LFSR",
   "author": "alto777_LFSR",

--- a/src/Psychtone.cpp
+++ b/src/Psychtone.cpp
@@ -222,19 +222,20 @@ setting value d0es not set physical angle
 struct MyModuleDisplay : TransparentWidget {
 	Psychtone *module;
 	int frame = 0;
-	std::shared_ptr<Font> font;
 
 	MyModuleDisplay() {
-		font = APP->window->loadFont(asset::plugin(pluginInstance, "res/fonts/Sudo.ttf"));
 	}
 
 	void draw(const DrawArgs &args) override {
+		std::shared_ptr<Font> font = APP->window->loadFont(asset::plugin(pluginInstance, "res/fonts/Sudo.ttf"));
+		if (!font)
+		  return;
 		nvgFontSize(args.vg, 16);
 		nvgFontFaceId(args.vg, font->handle);
 		nvgTextLetterSpacing(args.vg, -2);
 
 		nvgFillColor(args.vg, nvgRGBA(0xe0, 0xe0, 0xff, 0x80));
-		char text[128];
+		char text[128] = "";
 		if (module) {
 		  snprintf(text, sizeof(text), "= %x", module->printValue);
 		}


### PR DESCRIPTION
Converted the plugin to VCV Rack V2. It's less painful than the V1 migration, but there are a few things you need to verify to be compliant. I'll have packages for Linux, Mac and Windows posted under the Issues [post for migration](https://github.com/alto777/LFSR/issues/8) for users to test the re-built plugin.